### PR TITLE
通过合并对象的方式防止元素上的style自定义样式被覆盖

### DIFF
--- a/src/directive/dashboard.js
+++ b/src/directive/dashboard.js
@@ -43,10 +43,13 @@ export default {
             }
             // 绑定style
             const _bindStyleText = () => {
-                el.style = `transform-origin: 0 0;
-                        transform: scale(${scaling},${scaling}) translate(${translate});
-                        width:${designWidth}px;
-                        height:${designHeight}px;`
+                let s = {
+                        "transform-origin": "0 0",
+                        transform: `scale(${scaling},${scaling}) translate(${translate})`,
+                        width: `${designWidth}px`,
+                        height: `${designHeight}px`
+                    }
+                Object.assign(el.style, s)
             }
             // 窗口变化后重新计算
             let resize = () => {


### PR DESCRIPTION
通过合并对象的方式防止元素上的style自定义样式被覆盖，el.style他的类型是一个object，如果直接粗暴赋值会导致当前元素的style内容被覆盖，因此，使用assign的方式合并到el.style上，如此可以添加指令的样式又不会妨碍原来的样式，但是也有可能会覆盖原来的style里写的东西